### PR TITLE
Add test helper to allow static test which are reported by the test framework, and fixes errors

### DIFF
--- a/indirect_test.cc
+++ b/indirect_test.cc
@@ -766,9 +766,10 @@ TEST(IndirectTest, InteractionWithUnorderedMap) {
 }
 
 TEST(IndirectTest, InteractionWithSizedAllocators) {
-  static_assert(sizeof(xyz::indirect<int>) == sizeof(int*));
-  static_assert(sizeof(xyz::indirect<int, xyz::TrackingAllocator<int>>) ==
-                sizeof(int*) + sizeof(xyz::TrackingAllocator<int>));
+  EXPECT_TRUE(xyz::static_test<sizeof(xyz::indirect<int>) == sizeof(int*)>());
+  EXPECT_TRUE(xyz::static_test<
+              sizeof(xyz::indirect<int, xyz::TrackingAllocator<int>>) ==
+              (sizeof(int*) + sizeof(xyz::TrackingAllocator<int>))>());
 }
 
 #ifdef XYZ_HAS_STD_MEMORY_RESOURCE

--- a/indirect_test.cc
+++ b/indirect_test.cc
@@ -32,6 +32,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <map>
 
 #include "feature_check.h"
+#include "test_helpers.h"
 #include "tracking_allocator.h"
 #ifdef XYZ_HAS_STD_MEMORY_RESOURCE
 #include <memory_resource>

--- a/polymorphic_test.cc
+++ b/polymorphic_test.cc
@@ -41,6 +41,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <utility>
 
 #include "feature_check.h"
+#include "test_helpers.h"
 #include "tracking_allocator.h"
 #ifdef XYZ_HAS_STD_IN_PLACE_TYPE_T
 namespace xyz {
@@ -647,9 +648,10 @@ TEST(PolymorphicTest, InteractionWithUnorderedMap) {
 }
 
 TEST(PolymorphicTest, InteractionWithSizedAllocators) {
-  static_assert(sizeof(xyz::polymorphic<int>) == sizeof(int*));
-  static_assert(sizeof(xyz::polymorphic<int, xyz::TrackingAllocator<int>>) ==
-                sizeof(int*) + sizeof(xyz::TrackingAllocator<int>));
+  EXPECT_TRUE(xyz::static_test<
+              sizeof(xyz::polymorphic<int, xyz::TrackingAllocator<int>>) ==
+              (sizeof(xyz::polymorphic<int>) +
+               sizeof(xyz::TrackingAllocator<int>))>());
 }
 
 struct BaseA {

--- a/test_helpers.h
+++ b/test_helpers.h
@@ -1,0 +1,34 @@
+/* Copyright (c) 2016 The Value Types Authors. All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+==============================================================================*/
+
+#ifndef XYZ_TEST_HELPERS_H
+#define XYZ_TEST_HELPERS_H
+
+namespace xyz {
+
+template <bool B>
+constexpr bool static_test() {
+  static_assert(B);
+  return B;
+}
+
+}  // namespace xyz
+
+#endif  // XYZ_TEST_HELPERS_H


### PR DESCRIPTION
This should address the original intention to statically test, but also tie the test result into the test system output which `static_asset` will not alone captute.